### PR TITLE
fixes typo in ReadMe text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the source code behind our project to collect political ads on Facebook. Built versions are available for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/facebook-ad-collector/) and [Chrome](https://chrome.google.com/webstore/detail/facebook-political-ad-col/enliecaalhkhhihcmnbjfmmjkljlcinl).
 
-We're asking our readers to use this extension when they are browsing Facebook. While they are on a background script to collect ads they see. The extension shows those ads to users and asks them to decide whether or not a particular ad is political. We use those ratings to train a naive bayes classifier that then automatically rates the other ads we collected. The extension asks the server for the most recent ads that we've classified as political so that users can see political ads they haven't seen. We're careful to protect our user's privacy by not sending identifying information to our backend server.
+We're asking our readers to use this extension when they are browsing Facebook. While they are on a background script runs to collect ads they see. The extension shows those ads to users and asks them to decide whether or not a particular ad is political. We use those ratings to train a naive bayes classifier that then automatically rates the other ads we collected. The extension asks the server for the most recent ads that we've classified as political so that users can see political ads they haven't seen. We're careful to protect our user's privacy by not sending identifying information to our backend server.
 
 We're open sourcing this project because we'd love your help. Collecting these ads is challenging, and the more eyes on the problem the better.
 


### PR DESCRIPTION
"...a background script to collect ads they see." ==> "...a background script **runs** to collect..."