### PR TITLE
checkSponsor() may not be flagging Dutch sponsored posts

### DIFF
--- a/extension/src/parser.js
+++ b/extension/src/parser.js
@@ -73,6 +73,7 @@ const checkSponsor = node => {
         .getComputedStyle(a, ":after")
         .getPropertyValue("content");
       return [
+		"Gesponsord",
         "Sponsored",
         "Gesponsert",
         "Sponsrad",
@@ -83,7 +84,11 @@ const checkSponsor = node => {
         "Sponsorizzata",
         "Chartered"
       ].some(sponsor => {
-        if (text === sponsor || style === `"${sponsor}"`) return true;
+        if (text === sponsor || style === `"${sponsor}"`) {
+			console.log(`Node is sponsored because node text ${text} matched expected string ${sponsor}. Dumping node...`);
+			console.log(node)
+			return true;
+		}
         return false;
       });
     }

--- a/extension/src/parser.js
+++ b/extension/src/parser.js
@@ -84,11 +84,7 @@ const checkSponsor = node => {
         "Sponsorizzata",
         "Chartered"
       ].some(sponsor => {
-        if (text === sponsor || style === `"${sponsor}"`) {
-			console.log(`Node is sponsored because node text ${text} matched expected string ${sponsor}. Dumping node...`);
-			console.log(node)
-			return true;
-		}
+        if (text === sponsor || style === `"${sponsor}"`) return true;
         return false;
       });
     }

--- a/extension/src/parser.js
+++ b/extension/src/parser.js
@@ -73,7 +73,7 @@ const checkSponsor = node => {
         .getComputedStyle(a, ":after")
         .getPropertyValue("content");
       return [
-		"Gesponsord",
+        "Gesponsord",
         "Sponsored",
         "Gesponsert",
         "Sponsrad",


### PR DESCRIPTION
I may be completely off the mark here, but I found it odd that the array of expected 'Sponsored'-texts in checkSponsor() didn't include the Dutch flag for sponsored posts. After a rudimentary test it seems that this is indeed the case:

With addition of 'Gesponsord':
![image](https://user-images.githubusercontent.com/18357629/36636853-bfdd4226-19ce-11e8-8769-5617f8c91f94.png)

Without:
![image](https://user-images.githubusercontent.com/18357629/36636854-cc3bdadc-19ce-11e8-8d35-c0c1ec10944c.png)

The PR adds this string to the array of expected strings, but you may of course add this flag to the codebase at your own accord if my concerns are indeed valid. If this is simply an error in judgement on my part you may of course close this PR.