### PR TITLE
Hotfix for permalinks

### DIFF
--- a/backend/server/public/__tests__/components/frontend.js
+++ b/backend/server/public/__tests__/components/frontend.js
@@ -1,8 +1,11 @@
 import React from "react";
-import Enzyme, { mount } from "enzyme";
+import Enzyme, { mount, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { FrontEnd } from "../../src/components/frontend.jsx";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
+import AdDetail from "components/addetail.jsx";
+import AdList from "components/adlist.jsx";
+
 Enzyme.configure({ adapter: new Adapter() });
 
 function setup(path) {
@@ -25,6 +28,29 @@ describe("components", () => {
         ads: []
       });
       expect(enzymeWrapper.find("#app")).toHaveLength(1);
+    });
+
+    // via https://stackoverflow.com/questions/41531465/how-to-test-react-router-by-enzyme
+  });
+  describe("FrontEnd (routing)", () => {
+    const enzymeWrapper = shallow(
+      <MemoryRouter initialEntries={["/facebook-ads/"]}>
+        <FrontEnd />
+      </MemoryRouter>
+    )
+      .dive()
+      .dive();
+    const pathMap = enzymeWrapper.find(Route).reduce((pathMap, route) => {
+      const routeProps = route.props();
+      pathMap[routeProps.path] = routeProps.component;
+      return pathMap;
+    }, {});
+
+    it("should render the Ads dashboard for route /", () => {
+      expect(pathMap["/facebook-ads"]).toBe(AdList);
+    });
+    it("should render AdDetail for routes with an ad ID", () => {
+      expect(pathMap["/facebook-ads/ad/:ad_id"]).toBe(AdDetail);
     });
   });
 });

--- a/backend/server/src/server.rs
+++ b/backend/server/src/server.rs
@@ -152,6 +152,7 @@ impl Service for AdServer {
                     r"^/facebook-ads/?$",
                     r"^/facebook-ads/admin/?(.*)?$",
                     r"^/facebook-ads/ads/?(\d+)?$",
+                    r"^/facebook-ads/ad/?(\d+)?$",
                 ]).unwrap();
                 // generic restful routing regex for distinguishing subroutes at the collection
                 // and those at a specific element.  I'm sure I will understand
@@ -179,6 +180,7 @@ impl Service for AdServer {
                             None => Either::B(self.lang(req, |req, lang| self.search(req, lang))),
                         }
                     }
+                    Some(&3) => Either::B(self.file("public/index.html", ContentType::html())), // this is the permalinks!
                     Some(&_) => not_found,
                 }
             }

--- a/backend/server/tests/restful_routing_test.rs
+++ b/backend/server/tests/restful_routing_test.rs
@@ -12,6 +12,7 @@ use hyper::{Client, Method, Request};
 use tokio_core::reactor::Core;
 use serde_json::Value;
 use hyper::header::{qitem, AcceptLanguage, LanguageTag};
+use std::str;
 
 #[test]
 fn test_index_url() {
@@ -72,7 +73,130 @@ fn test_individual_ad_url() {
     let work = client.request(req).and_then(|res| {
         res.body().concat2().and_then(move |body| {
             let v: Value = serde_json::from_slice(&body).unwrap();
-            assert_eq!(v["ads"].as_array().unwrap().len(), 1);
+            assert_eq!(v["id"], "23842729393560096");
+            Ok(())
+        })
+    });
+    core.run(work).unwrap();
+}
+
+// ensuring we return the right HTML page for React to do its thing.
+#[test]
+fn test_admin_url_without_slash() {
+    let mut core = Core::new().unwrap();
+    let client = Client::new(&core.handle());
+    let uri = "http://localhost:8080/facebook-ads/admin".parse().unwrap();
+    let mut req = Request::new(Method::Get, uri);
+    let mut langtag: LanguageTag = Default::default();
+    langtag.language = Some("en".to_owned());
+    langtag.region = Some("US".to_owned());
+    req.headers_mut().set(AcceptLanguage(vec![qitem(langtag)]));
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |body| {
+            assert!(
+                str::from_utf8(&body)
+                    .unwrap()
+                    .contains("<title>Admin: Facebook Political Ad Collector</title>")
+            );
+            Ok(())
+        })
+    });
+    core.run(work).unwrap();
+}
+
+#[test]
+fn test_admin_url_with_slash() {
+    let mut core = Core::new().unwrap();
+    let client = Client::new(&core.handle());
+    let uri = "http://localhost:8080/facebook-ads/admin/".parse().unwrap();
+    let mut req = Request::new(Method::Get, uri);
+    let mut langtag: LanguageTag = Default::default();
+    langtag.language = Some("en".to_owned());
+    langtag.region = Some("US".to_owned());
+    req.headers_mut().set(AcceptLanguage(vec![qitem(langtag)]));
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |body| {
+            assert!(
+                str::from_utf8(&body)
+                    .unwrap()
+                    .contains("<title>Admin: Facebook Political Ad Collector</title>")
+            );
+            Ok(())
+        })
+    });
+    core.run(work).unwrap();
+}
+
+#[test]
+fn test_index_html_url_without_slash() {
+    let mut core = Core::new().unwrap();
+    let client = Client::new(&core.handle());
+    let uri = "http://localhost:8080/facebook-ads".parse().unwrap();
+    let mut req = Request::new(Method::Get, uri);
+    let mut langtag: LanguageTag = Default::default();
+    langtag.language = Some("en".to_owned());
+    langtag.region = Some("US".to_owned());
+    req.headers_mut().set(AcceptLanguage(vec![qitem(langtag)]));
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |body| {
+            assert!(
+                str::from_utf8(&body)
+                    .unwrap()
+                    .contains("<title>Facebook Political Ad Collector</title>")
+            );
+            Ok(())
+        })
+    });
+    core.run(work).unwrap();
+}
+
+#[test]
+fn test_index_html_url_with_slash() {
+    let mut core = Core::new().unwrap();
+    let client = Client::new(&core.handle());
+    let uri = "http://localhost:8080/facebook-ads/".parse().unwrap();
+    let mut req = Request::new(Method::Get, uri);
+    let mut langtag: LanguageTag = Default::default();
+    langtag.language = Some("en".to_owned());
+    langtag.region = Some("US".to_owned());
+    req.headers_mut().set(AcceptLanguage(vec![qitem(langtag)]));
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |body| {
+            assert!(
+                str::from_utf8(&body)
+                    .unwrap()
+                    .contains("<title>Facebook Political Ad Collector</title>")
+            );
+            Ok(())
+        })
+    });
+    core.run(work).unwrap();
+}
+
+#[test]
+fn test_ad_permalink_url_goes_to_index_html_url() {
+    let mut core = Core::new().unwrap();
+    let client = Client::new(&core.handle());
+    let uri = "http://localhost:8080/facebook-ads/ad/23842672388160612"
+        .parse()
+        .unwrap();
+    let mut req = Request::new(Method::Get, uri);
+    let mut langtag: LanguageTag = Default::default();
+    langtag.language = Some("en".to_owned());
+    langtag.region = Some("US".to_owned());
+    req.headers_mut().set(AcceptLanguage(vec![qitem(langtag)]));
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |body| {
+            assert!(
+                str::from_utf8(&body)
+                    .unwrap()
+                    .contains("<title>Facebook Political Ad Collector</title>")
+            );
             Ok(())
         })
     });

--- a/backend/server/tests/targeting_parser_test.rs
+++ b/backend/server/tests/targeting_parser_test.rs
@@ -44,11 +44,8 @@ fn getting_targets() {
 
     let connection = common::connect();
     common::seed_political(&connection);
-
     let db_pool = common::connect_pool();
-    let options: HashMap<String, String> = HashMap::new();
-
-    let t: Vec<Targets> = Targets::get("en-US", &db_pool, &options).unwrap();
+    let t: Vec<Targets> = Targets::get("en-US", &Some(1), &None, &db_pool).unwrap();
     assert!(t.get(0).is_some());
 
     common::unseed(&connection);


### PR DESCRIPTION
A previous change to routing stuff broke the route for permalinks. We need the permalinks to work for tomorrow (microsite). 

This fixes the routing and adds some routing related tests, in both Rust and in React.