### PR TITLE
Add migrations for lower_page and targetings columns in ads table

### DIFF
--- a/backend/server/migrations/2018-06-19-134846_add_lower_page/down.sql
+++ b/backend/server/migrations/2018-06-19-134846_add_lower_page/down.sql
@@ -1,0 +1,1 @@
+alter table ads drop column lower_page;

--- a/backend/server/migrations/2018-06-19-134846_add_lower_page/up.sql
+++ b/backend/server/migrations/2018-06-19-134846_add_lower_page/up.sql
@@ -1,0 +1,1 @@
+alter table ads add column lower_page text;

--- a/backend/server/migrations/2018-06-19-141914_add_targetings_to_ads/down.sql
+++ b/backend/server/migrations/2018-06-19-141914_add_targetings_to_ads/down.sql
@@ -1,0 +1,1 @@
+alter table ads drop column targetings;

--- a/backend/server/migrations/2018-06-19-141914_add_targetings_to_ads/up.sql
+++ b/backend/server/migrations/2018-06-19-141914_add_targetings_to_ads/up.sql
@@ -1,0 +1,1 @@
+alter table ads add column targetings text array;


### PR DESCRIPTION
These two columns are referenced in `backend/server/model.rs`

Without the migrations, the server was throwing an error about these missing columns.