### PR TITLE
detect hebrew sponsored ads

### DIFF
--- a/extension/src/parser.js
+++ b/extension/src/parser.js
@@ -565,7 +565,8 @@ const sponsored_translations = [
   "Apmaksāta", // lv-LV (cuts off reklāma as part of the thing that gets rid of the U.S. disclaimer)
   "რეკლამა", // ka-GE
   "Реклама", // ru
-  "Publicidad" // es
+  "Publicidad", // es
+  "ממומן" //he
 ];
 export const checkSponsor = node => {
   return Array.from(node.querySelectorAll(".clearfix a, .ego_section a")).some(


### PR DESCRIPTION
add "ממומן" (sponsored in Hebrew) to the list of known translations.